### PR TITLE
Fixed compilation error due to recursive #include

### DIFF
--- a/include/klee/ExecutionState.h
+++ b/include/klee/ExecutionState.h
@@ -16,6 +16,7 @@
 
 // FIXME: We do not want to be exposing these? :(
 #include "../../lib/Core/AddressSpace.h"
+#include "../../lib/Core/SymbolicError.h"
 #include "klee/Internal/Module/KInstIterator.h"
 
 #include <map>
@@ -30,7 +31,6 @@ struct KFunction;
 struct KInstruction;
 class MemoryObject;
 class PTreeNode;
-class SymbolicError;
 struct InstructionInfo;
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const MemoryMap &mm);
@@ -142,7 +142,7 @@ public:
   /// @brief Set of used array names for this state.  Used to avoid collisions.
   std::set<std::string> arrayNames;
 
-  //@brier Symbolic error information
+  //@brief Symbolic error information
   SymbolicError *symbolicError;
 
   std::string getFnAlias(std::string fn);

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "SymbolicError.h"
 #include "klee/ExecutionState.h"
 
 #include "klee/Internal/Module/Cell.h"

--- a/lib/Core/SymbolicError.h
+++ b/lib/Core/SymbolicError.h
@@ -9,10 +9,17 @@
 #define KLEE_SYMBOLICERROR_H_
 
 #include "klee/Expr.h"
-#include "Executor.h"
 #include "klee/util/ArrayCache.h"
 
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 3)
+#include "llvm/IR/Instructions.h"
+#else
+#include "llvm/Instructions.h"
+#endif
+
 namespace klee {
+class Executor;
+
 class SymbolicError {
 
 	std::map<Expr *, ref<Expr> > valueErrorMap;


### PR DESCRIPTION
ExecutionState.h should include SymbolicError.h, but this creates cyclic includes (because Executor.h included from SymbolicError.h in turn includes ExecutionState.h, which then includes SymbolicError.h). Fixed the cycle by un-include Executor.h from SymbolicError.h.
